### PR TITLE
DB saves resource filenames for weather icons

### DIFF
--- a/app/src/main/java/gov/wa/wsdot/android/wsdot/provider/WSDOTDatabase.java
+++ b/app/src/main/java/gov/wa/wsdot/android/wsdot/provider/WSDOTDatabase.java
@@ -107,7 +107,7 @@ public class WSDOTDatabase extends SQLiteOpenHelper {
                 + MountainPassesColumns.MOUNTAIN_PASS_RESTRICTION_TWO_DIRECTION + " TEXT,"
                 + MountainPassesColumns.MOUNTAIN_PASS_CAMERA + " TEXT,"
                 + MountainPassesColumns.MOUNTAIN_PASS_FORECAST + " TEXT,"
-                + MountainPassesColumns.MOUNTAIN_PASS_WEATHER_ICON + " INTEGER,"
+                + MountainPassesColumns.MOUNTAIN_PASS_WEATHER_ICON + " TEXT,"
                 + MountainPassesColumns.MOUNTAIN_PASS_IS_STARRED + " INTEGER NOT NULL default 0);");
         
         db.execSQL("CREATE TABLE " + Tables.TRAVEL_TIMES + " ("

--- a/app/src/main/java/gov/wa/wsdot/android/wsdot/provider/WSDOTDatabase.java
+++ b/app/src/main/java/gov/wa/wsdot/android/wsdot/provider/WSDOTDatabase.java
@@ -167,7 +167,7 @@ public class WSDOTDatabase extends SQLiteOpenHelper {
 		Log.d(TAG, "onUpgrade() from " + oldVersion + " to " + newVersion);
 		
 		int version = oldVersion;
-		
+
 		switch (version) {
     		case VER_1:
     		    Log.i(TAG, "Performing upgrade for DB version " + version);
@@ -207,34 +207,20 @@ public class WSDOTDatabase extends SQLiteOpenHelper {
 
             case VER_5:
 				Log.i(TAG, "Performing upgrade for DB version " + version);
-
-
-
-				db.execSQL("DROP TABLE IF EXISTS " + Tables.MOUNTAIN_PASSES);
-				db.execSQL("CREATE TABLE " + Tables.MOUNTAIN_PASSES + " ("
-						+ BaseColumns._ID + " INTEGER PRIMARY KEY AUTOINCREMENT,"
-						+ MountainPassesColumns.MOUNTAIN_PASS_ID + " INTEGER,"
-						+ MountainPassesColumns.MOUNTAIN_PASS_NAME + " TEXT,"
-						+ MountainPassesColumns.MOUNTAIN_PASS_WEATHER_CONDITION + " TEXT,"
-						+ MountainPassesColumns.MOUNTAIN_PASS_ELEVATION + " TEXT,"
-						+ MountainPassesColumns.MOUNTAIN_PASS_TRAVEL_ADVISORY_ACTIVE + " TEXT,"
-						+ MountainPassesColumns.MOUNTAIN_PASS_ROAD_CONDITION + " TEXT,"
-						+ MountainPassesColumns.MOUNTAIN_PASS_TEMPERATURE + " TEXT,"
-						+ MountainPassesColumns.MOUNTAIN_PASS_DATE_UPDATED + " TEXT,"
-						+ MountainPassesColumns.MOUNTAIN_PASS_RESTRICTION_ONE + " TEXT,"
-						+ MountainPassesColumns.MOUNTAIN_PASS_RESTRICTION_ONE_DIRECTION + " TEXT,"
-						+ MountainPassesColumns.MOUNTAIN_PASS_RESTRICTION_TWO + " TEXT,"
-						+ MountainPassesColumns.MOUNTAIN_PASS_RESTRICTION_TWO_DIRECTION + " TEXT,"
-						+ MountainPassesColumns.MOUNTAIN_PASS_CAMERA + " TEXT,"
-						+ MountainPassesColumns.MOUNTAIN_PASS_FORECAST + " TEXT,"
-						+ MountainPassesColumns.MOUNTAIN_PASS_WEATHER_ICON + " TEXT,"
-						+ MountainPassesColumns.MOUNTAIN_PASS_IS_STARRED + " INTEGER NOT NULL default 0);");
-
-                db.execSQL("UPDATE " + Tables.CACHES + " SET " + CachesColumns.CACHE_LAST_UPDATED + " =0 WHERE "
-                        + CachesColumns.CACHE_TABLE_NAME + "='" + Tables.MOUNTAIN_PASSES + "' ");
+                db.beginTransaction();
+                try {
+                    versionSixUpdate(db);
+                    db.setTransactionSuccessful();
+                    version = VER_6;
+                } catch(Exception e) {
+                    // Error
+                    Log.e(TAG, "failed to upgrade to version 6");
+                    version = VER_5;
+                } finally {
+                    db.endTransaction();
+                }
 
 			case VER_6:
-				version = VER_6;
 				Log.i(TAG, "DB at version " + DATABASE_VERSION);
                 // Current version, no further action necessary.
 		}
@@ -296,5 +282,60 @@ public class WSDOTDatabase extends SQLiteOpenHelper {
 		db.execSQL("insert into cameras (id, title, url, latitude, longitude, has_video, road_name, is_starred) values (8063, 'US 2 MP 65 Stevens Pass Ski Lodge', 'http://images.wsdot.wa.gov/us2/stvldg/sumtwest.jpg', 47.7513, -121.10619, 0, 'US 2', 0);");
 		db.execSQL("insert into cameras (id, title, url, latitude, longitude, has_video, road_name, is_starred) values (9145, 'US 2 MP 62 Old Faithful Avalanche Zone', 'http://images.wsdot.wa.gov/us2/oldfaithful/oldfaithful.jpg', 47.724431, -121.134085, 0, 'US 2', 0);");
 	}
-	
+
+    /* Version 6:
+         Changed value of MOUNTAIN_PASS_WEATHER_ICON from INTEGER to TEXT.
+         DB now saves icon filename instead of dynamic resource ID.
+
+         Saves users favorite passes in update.
+
+         See: https://github.com/WSDOT/wsdot-android-app/issues/83
+    */
+    private void versionSixUpdate(SQLiteDatabase db){
+        db.execSQL(
+                "CREATE TABLE new_table("
+                        + BaseColumns._ID + " INTEGER PRIMARY KEY AUTOINCREMENT,"
+                        + MountainPassesColumns.MOUNTAIN_PASS_ID + " INTEGER,"
+                        + MountainPassesColumns.MOUNTAIN_PASS_NAME + " TEXT,"
+                        + MountainPassesColumns.MOUNTAIN_PASS_WEATHER_CONDITION + " TEXT,"
+                        + MountainPassesColumns.MOUNTAIN_PASS_ELEVATION + " TEXT,"
+                        + MountainPassesColumns.MOUNTAIN_PASS_TRAVEL_ADVISORY_ACTIVE + " TEXT,"
+                        + MountainPassesColumns.MOUNTAIN_PASS_ROAD_CONDITION + " TEXT,"
+                        + MountainPassesColumns.MOUNTAIN_PASS_TEMPERATURE + " TEXT,"
+                        + MountainPassesColumns.MOUNTAIN_PASS_DATE_UPDATED + " TEXT,"
+                        + MountainPassesColumns.MOUNTAIN_PASS_RESTRICTION_ONE + " TEXT,"
+                        + MountainPassesColumns.MOUNTAIN_PASS_RESTRICTION_ONE_DIRECTION + " TEXT,"
+                        + MountainPassesColumns.MOUNTAIN_PASS_RESTRICTION_TWO + " TEXT,"
+                        + MountainPassesColumns.MOUNTAIN_PASS_RESTRICTION_TWO_DIRECTION + " TEXT,"
+                        + MountainPassesColumns.MOUNTAIN_PASS_CAMERA + " TEXT,"
+                        + MountainPassesColumns.MOUNTAIN_PASS_FORECAST + " TEXT,"
+                        + MountainPassesColumns.MOUNTAIN_PASS_WEATHER_ICON + " TEXT,"
+                        + MountainPassesColumns.MOUNTAIN_PASS_IS_STARRED + " INTEGER NOT NULL default 0); "
+                        + " INSERT INTO new_table (SELECT "
+                        + BaseColumns._ID + ", "
+                        + MountainPassesColumns.MOUNTAIN_PASS_ID + ", "
+                        + MountainPassesColumns.MOUNTAIN_PASS_NAME + ", "
+                        + MountainPassesColumns.MOUNTAIN_PASS_WEATHER_CONDITION + ", "
+                        + MountainPassesColumns.MOUNTAIN_PASS_ELEVATION + ", "
+                        + MountainPassesColumns.MOUNTAIN_PASS_TRAVEL_ADVISORY_ACTIVE + ", "
+                        + MountainPassesColumns.MOUNTAIN_PASS_ROAD_CONDITION + ", "
+                        + MountainPassesColumns.MOUNTAIN_PASS_TEMPERATURE + ", "
+                        + MountainPassesColumns.MOUNTAIN_PASS_DATE_UPDATED + ", "
+                        + MountainPassesColumns.MOUNTAIN_PASS_RESTRICTION_ONE + ", "
+                        + MountainPassesColumns.MOUNTAIN_PASS_RESTRICTION_ONE_DIRECTION + ", "
+                        + MountainPassesColumns.MOUNTAIN_PASS_RESTRICTION_TWO + ", "
+                        + MountainPassesColumns.MOUNTAIN_PASS_RESTRICTION_TWO_DIRECTION + ", "
+                        + MountainPassesColumns.MOUNTAIN_PASS_CAMERA + ", "
+                        + MountainPassesColumns.MOUNTAIN_PASS_FORECAST + ", "
+                        + MountainPassesColumns.MOUNTAIN_PASS_IS_STARRED
+                        + " FROM " + Tables.MOUNTAIN_PASSES + "); "
+
+                        + " DROP TABLE " + Tables.MOUNTAIN_PASSES + "; "
+                        + " ALTER TABLE new_table RENAME TO " + Tables.MOUNTAIN_PASSES + ";"
+        );
+
+        db.execSQL("UPDATE " + Tables.CACHES + " SET " + CachesColumns.CACHE_LAST_UPDATED + " =0 WHERE "
+                + CachesColumns.CACHE_TABLE_NAME + "='" + Tables.MOUNTAIN_PASSES + "' ");
+
+    }
 }

--- a/app/src/main/java/gov/wa/wsdot/android/wsdot/provider/WSDOTDatabase.java
+++ b/app/src/main/java/gov/wa/wsdot/android/wsdot/provider/WSDOTDatabase.java
@@ -44,7 +44,8 @@ public class WSDOTDatabase extends SQLiteOpenHelper {
 	private static final int VER_3 = 3;
 	private static final int VER_4 = 4;
     private static final int VER_5 = 5;
-	private static final int DATABASE_VERSION = VER_5;
+	private static final int VER_6 = 6;
+	private static final int DATABASE_VERSION = VER_6;
 
     interface Tables {
     	String CACHES = "caches";
@@ -205,8 +206,36 @@ public class WSDOTDatabase extends SQLiteOpenHelper {
                         + LocationColumns.LOCATION_ZOOM + " INTEGER);");
 
             case VER_5:
-                version = VER_5;
-                Log.i(TAG, "DB at version " + DATABASE_VERSION);
+				Log.i(TAG, "Performing upgrade for DB version " + version);
+
+
+
+				db.execSQL("DROP TABLE IF EXISTS " + Tables.MOUNTAIN_PASSES);
+				db.execSQL("CREATE TABLE " + Tables.MOUNTAIN_PASSES + " ("
+						+ BaseColumns._ID + " INTEGER PRIMARY KEY AUTOINCREMENT,"
+						+ MountainPassesColumns.MOUNTAIN_PASS_ID + " INTEGER,"
+						+ MountainPassesColumns.MOUNTAIN_PASS_NAME + " TEXT,"
+						+ MountainPassesColumns.MOUNTAIN_PASS_WEATHER_CONDITION + " TEXT,"
+						+ MountainPassesColumns.MOUNTAIN_PASS_ELEVATION + " TEXT,"
+						+ MountainPassesColumns.MOUNTAIN_PASS_TRAVEL_ADVISORY_ACTIVE + " TEXT,"
+						+ MountainPassesColumns.MOUNTAIN_PASS_ROAD_CONDITION + " TEXT,"
+						+ MountainPassesColumns.MOUNTAIN_PASS_TEMPERATURE + " TEXT,"
+						+ MountainPassesColumns.MOUNTAIN_PASS_DATE_UPDATED + " TEXT,"
+						+ MountainPassesColumns.MOUNTAIN_PASS_RESTRICTION_ONE + " TEXT,"
+						+ MountainPassesColumns.MOUNTAIN_PASS_RESTRICTION_ONE_DIRECTION + " TEXT,"
+						+ MountainPassesColumns.MOUNTAIN_PASS_RESTRICTION_TWO + " TEXT,"
+						+ MountainPassesColumns.MOUNTAIN_PASS_RESTRICTION_TWO_DIRECTION + " TEXT,"
+						+ MountainPassesColumns.MOUNTAIN_PASS_CAMERA + " TEXT,"
+						+ MountainPassesColumns.MOUNTAIN_PASS_FORECAST + " TEXT,"
+						+ MountainPassesColumns.MOUNTAIN_PASS_WEATHER_ICON + " TEXT,"
+						+ MountainPassesColumns.MOUNTAIN_PASS_IS_STARRED + " INTEGER NOT NULL default 0);");
+
+                db.execSQL("UPDATE " + Tables.CACHES + " SET " + CachesColumns.CACHE_LAST_UPDATED + " =0 WHERE "
+                        + CachesColumns.CACHE_TABLE_NAME + "='" + Tables.MOUNTAIN_PASSES + "' ");
+
+			case VER_6:
+				version = VER_6;
+				Log.i(TAG, "DB at version " + DATABASE_VERSION);
                 // Current version, no further action necessary.
 		}
 

--- a/app/src/main/java/gov/wa/wsdot/android/wsdot/service/MountainPassesSyncService.java
+++ b/app/src/main/java/gov/wa/wsdot/android/wsdot/service/MountainPassesSyncService.java
@@ -56,9 +56,9 @@ public class MountainPassesSyncService extends IntentService {
 
 	private static final String DEBUG_TAG = "MountainPassesSyncService";
 	@SuppressLint("UseSparseArrays")
-	private static HashMap<Integer, String[]> weatherPhrases = new HashMap<Integer, String[]>();
+	private static HashMap<String, String[]> weatherPhrases = new HashMap<>();
 	@SuppressLint("UseSparseArrays")
-	private static HashMap<Integer, String[]> weatherPhrasesNight = new HashMap<Integer, String[]>();
+	private static HashMap<String, String[]> weatherPhrasesNight = new HashMap<>();
 	private static DateFormat parseDateFormat = new SimpleDateFormat("yyyy,M,d,H,m"); //e.g. [2010, 11, 2, 8, 22, 32, 883, 0, 0]
 	private static DateFormat displayDateFormat = new SimpleDateFormat("MMMM d, yyyy h:mm a");
 	private static final String MOUNTAIN_PASS_URL = "http://data.wsdot.wa.gov/mobile/MountainPassConditions.js.gz";
@@ -67,6 +67,7 @@ public class MountainPassesSyncService extends IntentService {
 		super("MountainPassesSyncService");
 	}
 
+	@SuppressLint("LongLogTag")
 	@Override
 	protected void onHandleIntent(Intent intent) {
 		ContentResolver resolver = getContentResolver();
@@ -129,8 +130,8 @@ public class MountainPassesSyncService extends IntentService {
 				JSONObject result = obj.getJSONObject("GetMountainPassConditionsResult");
 				JSONArray passConditions = result.getJSONArray("PassCondition");
 				String weatherCondition;
-				Integer weather_image;
-				Integer forecast_weather_image;
+				String weather_image_name;
+				String forecast_weather_image_name;
 				List<ContentValues> passes = new ArrayList<ContentValues>();
 				
 				int numConditions = passConditions.length();
@@ -138,7 +139,7 @@ public class MountainPassesSyncService extends IntentService {
 					JSONObject pass = passConditions.getJSONObject(j);
 					ContentValues passData = new ContentValues();
 					weatherCondition = pass.getString("WeatherCondition");
-					weather_image = getWeatherImage(weatherPhrases, weatherCondition);
+					weather_image_name = getWeatherImage(weatherPhrases, weatherCondition);
 
 				    String tempDate = pass.getString("DateUpdated");
 				    
@@ -169,17 +170,17 @@ public class MountainPassesSyncService extends IntentService {
 						JSONObject forecast = forecasts.getJSONObject(l);
 						
 						if (isNight(forecast.getString("Day"))) {
-							forecast_weather_image = getWeatherImage(weatherPhrasesNight, forecast.getString("ForecastText"));
+							forecast_weather_image_name = getWeatherImage(weatherPhrasesNight, forecast.getString("ForecastText"));
 						} else {
-							forecast_weather_image = getWeatherImage(weatherPhrases, forecast.getString("ForecastText"));
+							forecast_weather_image_name = getWeatherImage(weatherPhrases, forecast.getString("ForecastText"));
 						}
 						
-						forecast.put("weather_icon", forecast_weather_image);
+						forecast.put("weather_icon", forecast_weather_image_name);
 						
 						if (l == 0) {
 							if (weatherCondition.equals("")) {
 								weatherCondition = forecast.getString("ForecastText").split("\\.")[0] + ".";
-								weather_image = forecast_weather_image;
+								weather_image_name = forecast_weather_image_name;
 							}
 						}
 						
@@ -188,7 +189,7 @@ public class MountainPassesSyncService extends IntentService {
 					
 					passData.put(MountainPasses.MOUNTAIN_PASS_ID, pass.getString("MountainPassId"));
 					passData.put(MountainPasses.MOUNTAIN_PASS_NAME, pass.getString("MountainPassName"));
-					passData.put(MountainPasses.MOUNTAIN_PASS_WEATHER_ICON, weather_image);
+					passData.put(MountainPasses.MOUNTAIN_PASS_WEATHER_ICON, weather_image_name);
 					passData.put(MountainPasses.MOUNTAIN_PASS_FORECAST, forecastItems.toString());
 					passData.put(MountainPasses.MOUNTAIN_PASS_WEATHER_CONDITION, weatherCondition);
 					passData.put(MountainPasses.MOUNTAIN_PASS_DATE_UPDATED, mDateUpdated);
@@ -257,57 +258,57 @@ public class MountainPassesSyncService extends IntentService {
 		String[] weather_hail = {"ice pellets", "light ice pellets", "heavy ice pellets", "hail"};
 		String[] weather_thunderstorm = {"thunderstorm", "thunderstorms"};
 		
-		weatherPhrases.put(R.drawable.ic_list_sunny, weather_clear);
-		weatherPhrases.put(R.drawable.ic_list_cloudy_1, weather_few_clouds);
-		weatherPhrases.put(R.drawable.ic_list_cloudy_2, weather_partly_cloudy);
-		weatherPhrases.put(R.drawable.ic_list_cloudy_3, weather_cloudy);
-		weatherPhrases.put(R.drawable.ic_list_cloudy_4, weather_mostly_cloudy);
-		weatherPhrases.put(R.drawable.ic_list_overcast, weather_overcast);
-		weatherPhrases.put(R.drawable.ic_list_light_rain, weather_light_rain);
-		weatherPhrases.put(R.drawable.ic_list_shower_3, weather_rain);
-		weatherPhrases.put(R.drawable.ic_list_snow_4, weather_snow);
-		weatherPhrases.put(R.drawable.ic_list_fog, weather_fog);
-		weatherPhrases.put(R.drawable.ic_list_sleet, weather_sleet);
-		weatherPhrases.put(R.drawable.ic_list_hail, weather_hail);
-		weatherPhrases.put(R.drawable.ic_list_tstorm_3, weather_thunderstorm);
+		weatherPhrases.put("ic_list_sunny", weather_clear);
+		weatherPhrases.put("ic_list_cloudy_1", weather_few_clouds);
+		weatherPhrases.put("ic_list_cloudy_2", weather_partly_cloudy);
+		weatherPhrases.put("ic_list_cloudy_3", weather_cloudy);
+		weatherPhrases.put("ic_list_cloudy_4", weather_mostly_cloudy);
+		weatherPhrases.put("ic_list_overcast", weather_overcast);
+		weatherPhrases.put("ic_list_light_rain", weather_light_rain);
+		weatherPhrases.put("ic_list_shower_3", weather_rain);
+		weatherPhrases.put("ic_list_snow_4", weather_snow);
+		weatherPhrases.put("ic_list_fog", weather_fog);
+		weatherPhrases.put("ic_list_sleet", weather_sleet);
+		weatherPhrases.put("ic_list_hail", weather_hail);
+		weatherPhrases.put("ic_list_tstorm_3", weather_thunderstorm);
 		
-		weatherPhrasesNight.put(R.drawable.ic_list_sunny_night, weather_clear);
-		weatherPhrasesNight.put(R.drawable.ic_list_cloudy_1_night, weather_few_clouds);
-		weatherPhrasesNight.put(R.drawable.ic_list_cloudy_2_night, weather_partly_cloudy);
-		weatherPhrasesNight.put(R.drawable.ic_list_cloudy_3_night, weather_cloudy);
-		weatherPhrasesNight.put(R.drawable.ic_list_cloudy_4_night, weather_mostly_cloudy);
-		weatherPhrasesNight.put(R.drawable.ic_list_overcast, weather_overcast);
-		weatherPhrasesNight.put(R.drawable.ic_list_light_rain, weather_light_rain);
-		weatherPhrasesNight.put(R.drawable.ic_list_shower_3, weather_rain);
-		weatherPhrasesNight.put(R.drawable.ic_list_snow_4, weather_snow);
-		weatherPhrasesNight.put(R.drawable.ic_list_fog_night, weather_fog);
-		weatherPhrasesNight.put(R.drawable.ic_list_sleet, weather_sleet);
-		weatherPhrasesNight.put(R.drawable.ic_list_hail, weather_hail);
-		weatherPhrasesNight.put(R.drawable.ic_list_tstorm_3, weather_thunderstorm);
+		weatherPhrasesNight.put("ic_list_sunny_night", weather_clear);
+		weatherPhrasesNight.put("ic_list_cloudy_1_night", weather_few_clouds);
+		weatherPhrasesNight.put("ic_list_cloudy_2_night", weather_partly_cloudy);
+		weatherPhrasesNight.put("ic_list_cloudy_3_night", weather_cloudy);
+		weatherPhrasesNight.put("ic_list_cloudy_4_night", weather_mostly_cloudy);
+		weatherPhrasesNight.put("ic_list_overcast", weather_overcast);
+		weatherPhrasesNight.put("ic_list_light_rain", weather_light_rain);
+		weatherPhrasesNight.put("ic_list_shower_3", weather_rain);
+		weatherPhrasesNight.put("ic_list_snow_4", weather_snow);
+		weatherPhrasesNight.put("ic_list_fog_night", weather_fog);
+		weatherPhrasesNight.put("ic_list_sleet", weather_sleet);
+		weatherPhrasesNight.put("ic_list_hail", weather_hail);
+		weatherPhrasesNight.put("ic_list_tstorm_3", weather_thunderstorm);
 		
 		return;
 	}
 	
-	private static Integer getWeatherImage(HashMap<Integer, String[]> weatherPhrases, String weather) {
-		Integer image = R.drawable.weather_na;
-		Set<Entry<Integer, String[]>> set = weatherPhrases.entrySet();
-		Iterator<Entry<Integer, String[]>> i = set.iterator();
+	private static String getWeatherImage(HashMap<String, String[]> weatherPhrases, String weather) {
+		String image_name = "weather_na";
+		Set<Entry<String, String[]>> set = weatherPhrases.entrySet();
+		Iterator<Entry<String, String[]>> i = set.iterator();
 		
-		if (weather.equals("")) return image;
+		if (weather.equals("")) return image_name;
 
 		String s0 = weather.split("\\.")[0]; // Pattern match on first sentence only.
 		
 		while(i.hasNext()) {
-			Entry<Integer, String[]> me = i.next();
+			Entry<String, String[]> me = i.next();
 			for (String phrase: (String[])me.getValue()) {
 				if (s0.toLowerCase().startsWith(phrase)) {
-					image = (Integer)me.getKey();
-					return image;
+					image_name = (String)me.getKey();
+					return image_name;
 				}
 			}
 		}
 		
-		return image;
+		return image_name;
 	}
     
 	private static boolean isNight(String text) {

--- a/app/src/main/java/gov/wa/wsdot/android/wsdot/ui/home/FavoritesFragment.java
+++ b/app/src/main/java/gov/wa/wsdot/android/wsdot/ui/home/FavoritesFragment.java
@@ -36,6 +36,7 @@ import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.helper.ItemTouchHelper;
+import android.util.AttributeSet;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -169,7 +170,7 @@ public class FavoritesFragment extends BaseFragment implements
 
 		mFerriesSchedulesIntent = new Intent(getActivity(), FerriesSchedulesSyncService.class);
         getActivity().startService(mFerriesSchedulesIntent);
-		
+
 		mMountainPassesIntent = new Intent(getActivity(), MountainPassesSyncService.class);
         getActivity().startService(mMountainPassesIntent);
 		
@@ -555,7 +556,8 @@ public class FavoritesFragment extends BaseFragment implements
                     viewHolder.text.setTypeface(tf);
                 }
 
-                int icon = cursor.getInt(cursor.getColumnIndex(MountainPasses.MOUNTAIN_PASS_WEATHER_ICON));
+                int icon = getResources().getIdentifier(cursor.getString(cursor.getColumnIndex(MountainPasses.MOUNTAIN_PASS_WEATHER_ICON)),
+                        "drawable", getActivity().getPackageName());
                 viewHolder.icon.setImageResource(icon);
 
                 viewHolder.star_button.setVisibility(View.GONE);

--- a/app/src/main/java/gov/wa/wsdot/android/wsdot/ui/mountainpasses/MountainPassItemForecastFragment.java
+++ b/app/src/main/java/gov/wa/wsdot/android/wsdot/ui/mountainpasses/MountainPassItemForecastFragment.java
@@ -36,6 +36,7 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 
 import gov.wa.wsdot.android.wsdot.R;
+import gov.wa.wsdot.android.wsdot.provider.WSDOTContract;
 import gov.wa.wsdot.android.wsdot.shared.ForecastItem;
 import gov.wa.wsdot.android.wsdot.ui.BaseFragment;
 import gov.wa.wsdot.android.wsdot.util.decoration.SimpleDividerItemDecoration;
@@ -69,7 +70,7 @@ public class MountainPassItemForecastFragment extends BaseFragment {
 				f = new ForecastItem();
 				f.setDay(forecast.getString("Day"));
 				f.setForecastText(forecast.getString("ForecastText"));
-				f.setWeatherIcon(forecast.getInt("weather_icon"));
+				f.setWeatherIcon(getResources().getIdentifier(forecast.getString("weather_icon"), "drawable", getActivity().getPackageName()));
 				forecastItems.add(f);
 			}
         } catch (JSONException e) {

--- a/app/src/main/java/gov/wa/wsdot/android/wsdot/ui/mountainpasses/MountainPassesFragment.java
+++ b/app/src/main/java/gov/wa/wsdot/android/wsdot/ui/mountainpasses/MountainPassesFragment.java
@@ -299,7 +299,9 @@ public class MountainPassesFragment extends BaseFragment implements
                 mtpassVH.text.setTypeface(tf);
             }
 
-            int icon = cursor.getInt(cursor.getColumnIndex(MountainPasses.MOUNTAIN_PASS_WEATHER_ICON));
+            int icon = getResources().getIdentifier(cursor.getString(cursor.getColumnIndex(MountainPasses.MOUNTAIN_PASS_WEATHER_ICON)),
+                    "drawable", getActivity().getPackageName());
+
             mtpassVH.icon.setImageResource(icon);
 
             mtpassVH.star_button.setTag(cursor.getInt(cursor.getColumnIndex("_id")));


### PR DESCRIPTION
issue #83
#### Implementation Notes
* Changed the value of column MOUNTAIN_PASS_WEATHER_ICON from INTEGER to TEXT. This is so we can save the weather icons as their filename.
* The magical line that maps a filename to the resource ID.
`getResources().getIdentifier(cursor.getString(cursor.getColumnIndex(MountainPasses.MOUNTAIN_PASS_WEATHER_ICON)),"drawable", getActivity().getPackageName());`
* Bumped DB version to 6.
* [Data migration logic](https://github.com/WSDOT/wsdot-android-app/compare/master...loganSims:wsdot-83-ls1?expand=1#diff-810689665f4d444ae48a86e6d8d0570cR286). Used a transaction, on any failure will clear database.
*  Upgrading worked fine on the simulator.  <b> Should probably be tested on a physical device</b>.