### PR TITLE
Weather icon matching fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Added
+### Fixed
 - More weather phrases for icon matching in mountain pass weather reports.
+- Missing weather icons when reports did not include forecast in the first sentence. 
 
 ## [4.4.3] - 2016-09-15
 ### Fixed

--- a/app/src/main/java/gov/wa/wsdot/android/wsdot/service/MountainPassesSyncService.java
+++ b/app/src/main/java/gov/wa/wsdot/android/wsdot/service/MountainPassesSyncService.java
@@ -172,7 +172,7 @@ public class MountainPassesSyncService extends IntentService {
 						if (isNight(forecast.getString("Day"))) {
 							forecast_weather_image_name = getWeatherImage(weatherPhrasesNight, forecast.getString("ForecastText"));
 						} else {
-							forecast_weather_image_name = getWeatherImage(weatherPhrases,  forecast.getString("ForecastText"));
+							forecast_weather_image_name = getWeatherImage(weatherPhrases, forecast.getString("ForecastText"));
 						}
 						
 						forecast.put("weather_icon", forecast_weather_image_name);
@@ -301,7 +301,6 @@ public class MountainPassesSyncService extends IntentService {
 		for (String forecastPart: forecastArr) {
 			while(i.hasNext()) {
 				Entry<String, String[]> me = i.next();
-
 				for (String phrase: me.getValue()) {
 					if (forecastPart.toLowerCase().trim().startsWith(phrase)) {
 						image_name = me.getKey();

--- a/app/src/main/java/gov/wa/wsdot/android/wsdot/service/MountainPassesSyncService.java
+++ b/app/src/main/java/gov/wa/wsdot/android/wsdot/service/MountainPassesSyncService.java
@@ -172,7 +172,7 @@ public class MountainPassesSyncService extends IntentService {
 						if (isNight(forecast.getString("Day"))) {
 							forecast_weather_image_name = getWeatherImage(weatherPhrasesNight, forecast.getString("ForecastText"));
 						} else {
-							forecast_weather_image_name = getWeatherImage(weatherPhrases, forecast.getString("ForecastText"));
+							forecast_weather_image_name = getWeatherImage(weatherPhrases,  forecast.getString("ForecastText"));
 						}
 						
 						forecast.put("weather_icon", forecast_weather_image_name);
@@ -291,23 +291,26 @@ public class MountainPassesSyncService extends IntentService {
 	
 	private static String getWeatherImage(HashMap<String, String[]> weatherPhrases, String weather) {
 		String image_name = "weather_na";
-		Set<Entry<String, String[]>> set = weatherPhrases.entrySet();
-		Iterator<Entry<String, String[]>> i = set.iterator();
+		Set<Entry<String, String[]>> weatherSet = weatherPhrases.entrySet();
+		Iterator<Entry<String, String[]>> i = weatherSet.iterator();
 		
 		if (weather.equals("")) return image_name;
 
-		String s0 = weather.split("\\.")[0]; // Pattern match on first sentence only.
-		
-		while(i.hasNext()) {
-			Entry<String, String[]> me = i.next();
-			for (String phrase: (String[])me.getValue()) {
-				if (s0.toLowerCase().startsWith(phrase)) {
-					image_name = (String)me.getKey();
-					return image_name;
+		String[] forecastArr = weather.split("\\.");
+
+		for (String forecastPart: forecastArr) {
+			while(i.hasNext()) {
+				Entry<String, String[]> me = i.next();
+
+				for (String phrase: me.getValue()) {
+					if (forecastPart.toLowerCase().trim().startsWith(phrase)) {
+						image_name = me.getKey();
+						return image_name;
+					}
 				}
 			}
+			i = weatherSet.iterator();
 		}
-		
 		return image_name;
 	}
     


### PR DESCRIPTION
Rarely, forecasts can start with something like "Cooler. Partly
cloudy". The previous logic would only check the first sentence and
fail to find a match. Now reads each sentence until it finds a match.

Resolves #96