### PR TITLE
Checks for event banner in onResume

### DIFF
--- a/app/src/main/java/gov/wa/wsdot/android/wsdot/ui/home/DashboardFragment.java
+++ b/app/src/main/java/gov/wa/wsdot/android/wsdot/ui/home/DashboardFragment.java
@@ -56,10 +56,17 @@ public class DashboardFragment extends BaseFragment implements Injectable {
         root.findViewById(R.id.home_btn_amtrak).setOnClickListener(view -> startActivity(new Intent(getActivity(), AmtrakCascadesActivity.class)));
         root.findViewById(R.id.home_btn_my_routes).setOnClickListener(view -> startActivity(new Intent(getActivity(), MyRouteActivity.class)));
 
+        return root;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
         Boolean eventActive = prefs.getBoolean(getString(R.string.event_is_active), false);
-        LinearLayout banner_view = root.findViewById(R.id.event_banner);
-        TextView banner_text = root.findViewById(R.id.event_banner_text);
+        LinearLayout banner_view =  getView().findViewById(R.id.event_banner);
+        TextView banner_text = getView().findViewById(R.id.event_banner_text);
 
         if (eventActive) {
             banner_view.setVisibility(View.VISIBLE);
@@ -71,12 +78,6 @@ public class DashboardFragment extends BaseFragment implements Injectable {
             banner_view.setVisibility(View.GONE);
         }
 
-        return root;
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
         MyLogger.crashlyticsLog("Home", "Screen View", "DashboardFragment", 1);
     }
 }

--- a/app/src/main/java/gov/wa/wsdot/android/wsdot/ui/home/HomeActivity.java
+++ b/app/src/main/java/gov/wa/wsdot/android/wsdot/ui/home/HomeActivity.java
@@ -138,7 +138,6 @@ public class HomeActivity extends BaseActivity implements Injectable {
 
         tryDisplayNotificationTipView();
 
-
     }
 
     @Override
@@ -171,6 +170,7 @@ public class HomeActivity extends BaseActivity implements Injectable {
         AccessibilityManager am = (AccessibilityManager) getSystemService(ACCESSIBILITY_SERVICE);
 
         Boolean accessibilityEnabled = false;
+
         if (am != null){
             accessibilityEnabled = am.isEnabled();
         }


### PR DESCRIPTION
This makes it so the app doesnt need to restart to display an event banner on the home screen. Once the EventService finds an event, it will display the next time the user visits the home screen.